### PR TITLE
execute permissions 

### DIFF
--- a/module/customize.sh
+++ b/module/customize.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 ISOLATED="/data/adb/net-switch/isolated.json"
 if [ ! -f $ISOLATED ]; then
 	mkdir $(dirname $ISOLATED)
@@ -8,3 +7,4 @@ fi
 if [ "$KSU" = "true" ] || [ "$APATCH" = "true" ]; then
 	rm $MODPATH/action.sh
 fi
+set_perm_recursive "$MODPATH/system" 0 0 0755 0755


### PR DESCRIPTION
Typo in readme md  terminal usage , it should be "netswitch" instead of netstat and modified customize.sh to set execute permissions for 'netswitch' during installation 